### PR TITLE
Fix an outdated API command usage and a post-script run crash

### DIFF
--- a/Tiles to Layers.lua
+++ b/Tiles to Layers.lua
@@ -50,8 +50,7 @@ function TileSplitter(tile_w,tile_h,spr)
 
     -- Copy and paste the selection
     app.command.CopyMerged()
-    app.command.NewLayer()
-    app.command.Paste()
+    app.command.NewLayer{ ["fromClipboard"] = true }
 
     -- Rename the layer
     app.activeLayer.name = "Tile "..count

--- a/Touch Toolbar.lua
+++ b/Touch Toolbar.lua
@@ -14,5 +14,5 @@ dlg
   :button{text=">",onclick=function() app.command.GotoNextFrame() end}
   :button{text=">|",onclick=function() app.command.GotoLastFrame() end}
   :button{text="+",onclick=function() app.command.NewFrame() end}
-  :button{text="-",onclick=function() app.command.DeleteFrame() end}
+  :button{text="-",onclick=function() app.command.RemoveFrame() end}
   :show{wait=false}


### PR DESCRIPTION
Hiya, just checked all the example scripts to see if they work with the v1.3 beta, and found two scripts that didn't work correctly anymore! (both also didn't work with v1.2.27)

The `Tiles to Layers.lua` script would only copy the first tile region to each of the generated layer and also caused a crash whenever any of the created layers were selected in the timeline or drawn to via the pencil (yet hiding/showing these layers didn't cause a crash). The issue stopped as soon as I removed the call for `app.command.Paste()`.

And the `Touch Toolbar.lua` script just simply had an outdated API call.

Hope this is useful for maintenance and thanks for the awesome software!

### Aseprite and System version

* Aseprite version: v1.3-beta2-x64, Steam (beta branch). Also tested with v1.2.27, Humble Bundle (portable)
* System: Windows 10 x64